### PR TITLE
[codex] Move non-core dependencies to extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,30 +6,30 @@ version = "0.4.2"
 [deps]
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-DistributionsHEP = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
-FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Minuit2_Julia_Wrapper_jll = "65cff058-67fb-5034-9600-a8f6a0feb90b"
-Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DistributionsHEP = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
+FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [extensions]
 Minuit2FHistExt = ["FHist"]
-Minuit2PlotsExt = ["Plots", "FHist"]
 Minuit2OptimizationExt = ["Optimization"]
+Minuit2PlotsExt = ["Plots", "FHist"]
+Minuit2RooFitExt = ["Distributions", "DistributionsHEP", "FHist", "StatsBase"]
+Minuit2RooFitPlotsExt = ["Distributions", "DistributionsHEP", "FHist", "Plots", "RecipesBase", "StatsBase"]
 
 [compat]
 ComponentArrays = "0.15.28"
@@ -42,17 +42,23 @@ LinearAlgebra = "1"
 Minuit2_Julia_Wrapper_jll = "0.4.0"
 Optimization = "4.4.0"
 Plots = "1"
-Polynomials = "4.0.19"
 PrettyTables = "2.4.0"
 Random = "1"
 RecipesBase = "^1"
-SpecialFunctions = "2.5.0"
 StatsBase = "0.34.4"
 julia = "1.10"
 
 [extras]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DistributionsHEP = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
+FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "FiniteDiff", "Optimization", "QuadGK"]
+test = ["Test", "FiniteDiff", "Optimization", "QuadGK", "Distributions", "DistributionsHEP", "FHist", "Plots", "RecipesBase", "StatsBase"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -10,6 +10,8 @@ Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 Plots = "^1.40.17"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,6 @@
 using Documenter, Literate, Minuit2
+import Distributions, DistributionsHEP, FHist, RecipesBase, StatsBase
+using Minuit2.RooFit
  
 const tutorialsdir =  joinpath(@__DIR__, "src/tutorials")
 const project = @__DIR__

--- a/docs/src/tutorials/roofit_basics_lit.jl
+++ b/docs/src/tutorials/roofit_basics_lit.jl
@@ -17,8 +17,10 @@
 
 # Load the `Minuit2.RooFit` module and other needed modules.
 
-using Minuit2.RooFit
+using Minuit2
+import Distributions, DistributionsHEP, FHist, RecipesBase, StatsBase
 using Plots
+using Minuit2.RooFit
 theme(:boxed)
 
 # ## Setup the model
@@ -52,4 +54,3 @@ println("Sigma is $(gauss.sigma.value) ± $(gauss.sigma.error))")
 # ## Plot the fit result
 
 plot(result, title="Gaussian fit")
-

--- a/docs/src/tutorials/roofit_lit.jl
+++ b/docs/src/tutorials/roofit_lit.jl
@@ -20,8 +20,9 @@
 # and display results.
 
 using Minuit2
-using Minuit2.RooFit        # Load the RooFit module
+import Distributions, DistributionsHEP, FHist, RecipesBase, StatsBase
 using Plots                 # Plotting
+using Minuit2.RooFit        # Load the RooFit module
 theme(:boxed)
 # ## RooFit Modelling
 # The `RooFit` module is a powerful tool for defining and fitting models to data.
@@ -166,6 +167,4 @@ plot(result, components=[:bkg, :sig1, :sig2], legend=:topright)
 # The `draw_mncontour` function is used to plot the contours of the likelihood function in the parameter space.
 
 draw_mncontour(result.engine, :c, :μ)
-
-
 

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+DistributionsHEP = "0d0d6f60-fb7b-48ca-90bb-e14e8b1655a7"
 FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"

--- a/ext/Minuit2PlotsExt.jl
+++ b/ext/Minuit2PlotsExt.jl
@@ -1,7 +1,6 @@
 module Minuit2PlotsExt
 using Minuit2
-using Minuit2.RooFit
-using FHist, RecipesBase, Plots
+using FHist, Plots
 
 isdefined(Base, :get_extension) ? (using Plots) : (using ..Plots)
 
@@ -147,110 +146,6 @@ function visualize(cost::Minuit2.CostSum, is_valid, pars; nbins=50, kwargs...)
     n = plots |> length |> sqrt |> ceil |> Int 
     plt = plot(plots...; layout=(n, n))
     return plt
-end
-
-#----Visualize fit and model
-function Minuit2.visualize(m::Minuit, model::AbstractPdf; nbins=-1, components=(), kwargs...)
-    isnothing(m.cost) && throw(ArgumentError("Minuit object does not have a cost function"))
-    m.cost.ndim > 1 && throw(ArgumentError("Cost function dimension > 1 not supported"))
-    m.cost isa UnbinnedCostFunction && nbins == -1 && (nbins = 50)
-    plt = visualize(m.cost, m.is_valid, collect(m.values), nbins=nbins; kwargs...)
-    #---Components of the model
-    for c in components
-        comp, weight = model[c]
-        a, b = comp.x.limits
-        if m.cost isa UnbinnedNLL
-            nbins == -1 && (nbins = 50)
-            scale = weight * prod(Base.size(m.cost.data)) * (b-a)/nbins
-        elseif m.cost isa ExtendedUnbinnedNLL
-            nbins == -1 && (nbins = 50)
-            scale = weight * (b-a)/nbins
-        elseif m.cost isa BinnedNLL
-            nbins != -1 && nbins != comp.x.nbins && @warn "Forced #bins to $(comp.x.nbins)"
-            scale = weight * (b-a)/comp.x.nbins * sum(m.cost.bincounts)
-        elseif m.cost isa ExtendedBinnedNLL
-            nbins != -1 && nbins != comp.x.nbins && @warn "Forced #bins to $(comp.x.nbins)"
-            scale = weight * (b-a)/comp.x.nbins
-        end
-        func = x -> comp.pdf(x, (p.value for p in comp.params)...) * scale
-        plot!(plt, func; label="$(comp.name)", kwargs...)
-    end
-    return plt
-end
-#---Visualize PDF model
-function Minuit2.visualize(model::AbstractPdf; kwargs...)
-    isnothing(model.x) && throw(ArgumentError("Model does not have a variable"))
-    plt = plot(x->model(x), model.x.limits...; label="$(model.name)", kwargs...)
-    return plt
-end
-
-#---Plots.jl recipes-------------------------------------------------------------------------------
-global plot_attributes = Dict()    # a hacky way to pass attributes between recipes
-info(model) = join(["$(p.name) = $(round(p.value, sigdigits=3)) ± $(round(p.error, sigdigits=3))" for p in model.params], '\n')
-
-@recipe function f(pdf::AbstractPdf; components=())
-    seriestype --> :path
-    scale = get(plotattributes, :integral, get(plot_attributes, :integral, 1.))
-    @series begin
-        pdf_int = pdf isa AddPdf && pdf.extendable ? sum(f.value for f in pdf.fractions) : 1
-        linestyle := :solid
-        components != () && (label := string(pdf.name))
-        (x -> pdf.pdf(x, (p.value for p in pdf.params)...)*scale/pdf_int, pdf.x.limits...)
-    end
-    # Plot the components of the PDF
-    for c in components
-        comp, weight = pdf[c]
-        a, b = comp.x.limits
-        func = x -> comp.pdf(x, (p.value for p in comp.params)...)*scale*weight
-        @series begin
-            label := string(comp.name)
-            linestyle := :dash
-            (func, a, b)
-        end
-    end
-
-end
-
-@recipe function f(ds::DataSet)
-    seriestype --> :scatter
-    x = ds.observables[1]
-    label --> string(x.name)
-    ylabel --> "events"
-    markercolor --> :black
-    if ds.data isa AbstractHistogram
-        h = ds.data
-        bins = h |> nbins
-    else
-        bins = get(plotattributes, :bins, 0)
-        bins = bins > 0 ? bins : x.nbins > 0 ? x.nbins : 100
-        h = Hist1D(ds.data, binedges=range(x.limits..., bins+1))
-    end
-    x := bincenters(h)
-    y := bincounts(h)
-    yerr := sqrt.(bincounts(h))
-    # Save the attribuites for the plot
-    plot_attributes[:bins] = bins
-    plot_attributes[:integral] = integral(h, width=true) 
-    ()
-end
-
-@recipe function f(r::FitResult)
-    (; data, model) = r
-    legend --> :outerleft
-    legendfontsize --> 6
-    labelfontsize --> 8
-    legend_background_color --> :lightgray
-    ylabel --> "events"
-    xlabel --> string(r.model.x.name)
-    @series begin
-        label := "data"
-        color := :black
-        (data,)
-    end
-    @series begin
-        label --> info(model)
-        (model,)
-    end
 end
 
 #=

--- a/ext/Minuit2RooFitExt.jl
+++ b/ext/Minuit2RooFitExt.jl
@@ -1,0 +1,25 @@
+module Minuit2RooFitExt
+
+using Minuit2
+using Distributions
+using DistributionsHEP
+using FHist
+using StatsBase
+
+_generating_output() = ccall(:jl_generating_output, Cint, ()) == 1
+
+function __init__()
+    _generating_output() && return
+    isdefined(Minuit2.RooFit, :Distributions) ||
+        Core.eval(Minuit2.RooFit, :(const Distributions = $Distributions))
+    isdefined(Minuit2.RooFit, :DistributionsHEP) ||
+        Core.eval(Minuit2.RooFit, :(const DistributionsHEP = $DistributionsHEP))
+    isdefined(Minuit2.RooFit, :FHist) ||
+        Core.eval(Minuit2.RooFit, :(const FHist = $FHist))
+    isdefined(Minuit2.RooFit, :StatsBase) ||
+        Core.eval(Minuit2.RooFit, :(const StatsBase = $StatsBase))
+    isdefined(Minuit2.RooFit, :AbstractPdf) ||
+        Core.eval(Minuit2.RooFit, :(include(joinpath(@__DIR__, "..", "src", "roofit.jl"))))
+end
+
+end

--- a/ext/Minuit2RooFitPlotsExt.jl
+++ b/ext/Minuit2RooFitPlotsExt.jl
@@ -1,0 +1,29 @@
+module Minuit2RooFitPlotsExt
+
+using Minuit2
+using Distributions
+using DistributionsHEP
+using FHist
+using Plots
+using RecipesBase
+using StatsBase
+
+_generating_output() = ccall(:jl_generating_output, Cint, ()) == 1
+
+function __init__()
+    _generating_output() && return
+    isdefined(Minuit2.RooFit, :Distributions) ||
+        Core.eval(Minuit2.RooFit, :(const Distributions = $Distributions))
+    isdefined(Minuit2.RooFit, :DistributionsHEP) ||
+        Core.eval(Minuit2.RooFit, :(const DistributionsHEP = $DistributionsHEP))
+    isdefined(Minuit2.RooFit, :FHist) ||
+        Core.eval(Minuit2.RooFit, :(const FHist = $FHist))
+    isdefined(Minuit2.RooFit, :StatsBase) ||
+        Core.eval(Minuit2.RooFit, :(const StatsBase = $StatsBase))
+    isdefined(Minuit2.RooFit, :AbstractPdf) ||
+        Core.eval(Minuit2.RooFit, :(include(joinpath(@__DIR__, "..", "src", "roofit.jl"))))
+    isdefined(@__MODULE__, :plot_attributes) ||
+        Core.eval(@__MODULE__, :(include(joinpath(@__DIR__, "..", "src", "roofit_plots.jl"))))
+end
+
+end

--- a/src/Minuit2.jl
+++ b/src/Minuit2.jl
@@ -26,7 +26,14 @@ module Minuit2
     include("wrap.jl")
     include("cost.jl")
     include("api.jl")
-    include("roofit.jl")
+
+    module RooFit
+        export AbstractPdf, AbstractData, RealVar, ConstVar, DataSet, AbstractHistogram, FitResult
+        export Gaussian, Exponential, ArgusPdf, Chebyshev
+        export AddPdf, generate, distribution
+        export minuitkwargs, fitTo
+    end
+    export RooFit
 
     export draw_contour, draw_mncontour, draw_profile, draw_mnprofile, visualize, MigradOptimizer
 
@@ -55,4 +62,3 @@ module Minuit2
     end
 
 end
-

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,11 +1,47 @@
 using CxxWrap
 using PrettyTables
 using LinearAlgebra
-using Distributions
 
 import Base: values, show
 
 export FCN, Minuit, migrad!, hesse!, matrix, minos!, simplex!, scan!, contour, mncontour, profile, mnprofile
+
+_erf(x::Float64) = ccall((:erf, Base.Math.libm), Float64, (Float64,), x)
+_chisq_cdf_1(x::Real) = _erf(sqrt(Float64(x) / 2))
+_chisq_quantile_2(p::Real) = -2 * log1p(-Float64(p))
+
+function _norm_quantile(p::Real)
+    x = Float64(p)
+    0 < x < 1 || throw(ArgumentError("probability must be between 0 and 1"))
+
+    a = (-3.969683028665376e1, 2.209460984245205e2, -2.759285104469687e2,
+          1.383577518672690e2, -3.066479806614716e1, 2.506628277459239)
+    b = (-5.447609879822406e1, 1.615858368580409e2, -1.556989798598866e2,
+          6.680131188771972e1, -1.328068155288572e1)
+    c = (-7.784894002430293e-3, -3.223964580411365e-1, -2.400758277161838,
+         -2.549732539343734, 4.374664141464968, 2.938163982698783)
+    d = (7.784695709041462e-3, 3.224671290700398e-1, 2.445134137142996,
+         3.754408661907416)
+
+    plow = 0.02425
+    phigh = 1 - plow
+    if x < plow
+        q = sqrt(-2 * log(x))
+        return (((((c[1] * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) * q + c[6]) /
+               ((((d[1] * q + d[2]) * q + d[3]) * q + d[4]) * q + 1)
+    elseif x <= phigh
+        q = x - 0.5
+        r = q * q
+        return (((((a[1] * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * r + a[6]) * q /
+               (((((b[1] * r + b[2]) * r + b[3]) * r + b[4]) * r + b[5]) * r + 1)
+    else
+        q = sqrt(-2 * log1p(-x))
+        return -(((((c[1] * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) * q + c[6]) /
+                ((((d[1] * q + d[2]) * q + d[3]) * q + d[4]) * q + 1)
+    end
+end
+
+_chisq_quantile_1(p::Real) = abs2(_norm_quantile((1 + Float64(p)) / 2))
 
 """
     Minuit structure
@@ -576,8 +612,8 @@ minimisation for all other parameters of the cost function for each scan point.
 This requires many more function evaluations than running the Hesse algorithm.
 """
 function minos!(m::Minuit; cl=0.68, ncall=0, parameters=(), strategy=1)
-    cl >= 1.0 && (cl = cdf(Chisq(1), cl^2))    # convert sigmas into confidence level
-    factor = quantile(Chisq(1), cl)            # convert confidence level to errordef
+    cl >= 1.0 && (cl = _chisq_cdf_1(cl^2))     # convert sigmas into confidence level
+    factor = _chisq_quantile_1(cl)             # convert confidence level to errordef
 
     # If the function minimum does not exist or the last state was modified, run Hesse
     if m.fmin === nothing || !IsValid(m.fmin)
@@ -732,8 +768,8 @@ function mncontour(m::Minuit, x, y; cl=0.68, size=50, interpolated=0)
     ix, xname = keypair(m, x)
     iy, yname = keypair(m, y)
 
-    cl >= 1.0 && (cl = cdf(Chisq(1), cl^2))    # convert sigmas into confidence level
-    factor = quantile(Chisq(2), cl)            # convert confidence level to errordef
+    cl >= 1.0 && (cl = _chisq_cdf_1(cl^2))     # convert sigmas into confidence level
+    factor = _chisq_quantile_2(cl)             # convert confidence level to errordef
 
     m.is_valid || throw(ErrorException("Function minimum is not valid: $(m.fmin)"))
     m.fixed[ix] && throw(ErrorException("Cannot scan over fixed parameter $xname"))

--- a/src/roofit.jl
+++ b/src/roofit.jl
@@ -1,12 +1,18 @@
-module RooFit
-
-import Distributions: UnivariateDistribution, Exponential as _Exponential, Normal as _Normal, Uniform as _Uniform, pdf, cdf, truncated
-import FHist: Hist1D, AbstractHistogram
-import StatsBase: wsample, mean, std
 import Minuit2: BinnedNLL, ExtendedBinnedNLL, UnbinnedNLL, ExtendedUnbinnedNLL, CostFunction, Minuit, migrad!
-import DistributionsHEP: ArgusBG as ArgusBGDist, Chebyshev as ChebyshevDist
 import Base: getproperty, setproperty!, show, isconst, getindex, setindex!
 import Random: AbstractRNG, default_rng
+
+const _Exponential = Distributions.Exponential
+const _Normal = Distributions.Normal
+const _Uniform = Distributions.Uniform
+const pdf = Distributions.pdf
+const cdf = Distributions.cdf
+const truncated = Distributions.truncated
+const Hist1D = FHist.Hist1D
+const AbstractHistogram = FHist.AbstractHistogram
+const wsample = StatsBase.wsample
+const ArgusBGDist = DistributionsHEP.ArgusBG
+const ChebyshevDist = DistributionsHEP.Chebyshev
 
 
 export AbstractPdf, AbstractData, RealVar, ConstVar, DataSet, AbstractHistogram, FitResult
@@ -41,8 +47,8 @@ function getproperty(d::AbstractPdf, name::Symbol)
 end
 (model::AbstractPdf)(x) = model.pdf(x, (p.value for p in model.params)...)
 show(io::IO, d::AbstractPdf) = print(io, "$(nameof(typeof(d))){$(d.name)} PDF with parameters $([p.name for p in d.params])")
-mean(d::AbstractPdf) = mean(distribution(d))
-std(d::AbstractPdf) = std(distribution(d))
+StatsBase.mean(d::AbstractPdf) = StatsBase.mean(distribution(d))
+StatsBase.std(d::AbstractPdf) = StatsBase.std(distribution(d))
 function minuitkwargs(d::AbstractPdf; randomize=false)
     function value(p)
         if randomize
@@ -455,6 +461,3 @@ function getindex(d::AddPdf, c::Symbol)
     idx = findfirst(pdf -> pdf.name == c, d.pdfs)
     return d[idx]
 end
-
-end  # module RooFit
-export RooFit

--- a/src/roofit_plots.jl
+++ b/src/roofit_plots.jl
@@ -1,0 +1,107 @@
+using Minuit2
+using Minuit2.RooFit
+using FHist, RecipesBase, Plots
+
+#----Visualize fit and model
+function Minuit2.visualize(m::Minuit, model::AbstractPdf; nbins=-1, components=(), kwargs...)
+    isnothing(m.cost) && throw(ArgumentError("Minuit object does not have a cost function"))
+    m.cost.ndim > 1 && throw(ArgumentError("Cost function dimension > 1 not supported"))
+    m.cost isa UnbinnedCostFunction && nbins == -1 && (nbins = 50)
+    plt = visualize(m.cost, m.is_valid, collect(m.values), nbins=nbins; kwargs...)
+    #---Components of the model
+    for c in components
+        comp, weight = model[c]
+        a, b = comp.x.limits
+        if m.cost isa UnbinnedNLL
+            nbins == -1 && (nbins = 50)
+            scale = weight * prod(Base.size(m.cost.data)) * (b-a)/nbins
+        elseif m.cost isa ExtendedUnbinnedNLL
+            nbins == -1 && (nbins = 50)
+            scale = weight * (b-a)/nbins
+        elseif m.cost isa BinnedNLL
+            nbins != -1 && nbins != comp.x.nbins && @warn "Forced #bins to $(comp.x.nbins)"
+            scale = weight * (b-a)/comp.x.nbins * sum(m.cost.bincounts)
+        elseif m.cost isa ExtendedBinnedNLL
+            nbins != -1 && nbins != comp.x.nbins && @warn "Forced #bins to $(comp.x.nbins)"
+            scale = weight * (b-a)/comp.x.nbins
+        end
+        func = x -> comp.pdf(x, (p.value for p in comp.params)...) * scale
+        plot!(plt, func; label="$(comp.name)", kwargs...)
+    end
+    return plt
+end
+
+#---Visualize PDF model
+function Minuit2.visualize(model::AbstractPdf; kwargs...)
+    isnothing(model.x) && throw(ArgumentError("Model does not have a variable"))
+    plt = plot(x->model(x), model.x.limits...; label="$(model.name)", kwargs...)
+    return plt
+end
+
+#---Plots.jl recipes-------------------------------------------------------------------------------
+global plot_attributes = Dict()    # a hacky way to pass attributes between recipes
+info(model) = join(["$(p.name) = $(round(p.value, sigdigits=3)) ± $(round(p.error, sigdigits=3))" for p in model.params], '\n')
+
+@recipe function f(pdf::AbstractPdf; components=())
+    seriestype --> :path
+    scale = get(plotattributes, :integral, get(plot_attributes, :integral, 1.))
+    @series begin
+        pdf_int = pdf isa AddPdf && pdf.extendable ? sum(f.value for f in pdf.fractions) : 1
+        linestyle := :solid
+        components != () && (label := string(pdf.name))
+        (x -> pdf.pdf(x, (p.value for p in pdf.params)...)*scale/pdf_int, pdf.x.limits...)
+    end
+    # Plot the components of the PDF
+    for c in components
+        comp, weight = pdf[c]
+        a, b = comp.x.limits
+        func = x -> comp.pdf(x, (p.value for p in comp.params)...)*scale*weight
+        @series begin
+            label := string(comp.name)
+            linestyle := :dash
+            (func, a, b)
+        end
+    end
+end
+
+@recipe function f(ds::DataSet)
+    seriestype --> :scatter
+    x = ds.observables[1]
+    label --> string(x.name)
+    ylabel --> "events"
+    markercolor --> :black
+    if ds.data isa AbstractHistogram
+        h = ds.data
+        bins = h |> nbins
+    else
+        bins = get(plotattributes, :bins, 0)
+        bins = bins > 0 ? bins : x.nbins > 0 ? x.nbins : 100
+        h = Hist1D(ds.data, binedges=range(x.limits..., bins+1))
+    end
+    x := bincenters(h)
+    y := bincounts(h)
+    yerr := sqrt.(bincounts(h))
+    # Save the attribuites for the plot
+    plot_attributes[:bins] = bins
+    plot_attributes[:integral] = integral(h, width=true)
+    ()
+end
+
+@recipe function f(r::FitResult)
+    (; data, model) = r
+    legend --> :outerleft
+    legendfontsize --> 6
+    labelfontsize --> 8
+    legend_background_color --> :lightgray
+    ylabel --> "events"
+    xlabel --> string(r.model.x.name)
+    @series begin
+        label := "data"
+        color := :black
+        (data,)
+    end
+    @series begin
+        label --> info(model)
+        (model,)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,10 @@
 using ComponentArrays: ComponentArray
+import Distributions
+import DistributionsHEP
+import FHist
+import Plots
+import RecipesBase
+import StatsBase
 using Minuit2.RooFit
 using Random: seed!
 using Minuit2

--- a/test/test_roofit.jl
+++ b/test/test_roofit.jl
@@ -1,6 +1,7 @@
 using Minuit2.RooFit
 import Distributions: Exponential as _Exponential, Normal, pdf, cdf, truncated
 using FHist
+import Plots
 using QuadGK
 
 @testset "RooFit types" verbose=true begin
@@ -77,6 +78,7 @@ using QuadGK
         @test quadgk(x -> g.pdf(x), x.limits...)[1] ≈ 1.0f0
 
         @test show(devnull, g) === nothing
+        @test Plots.plot(g) isa Plots.Plot
     end
 
     @testset "Exponential" begin


### PR DESCRIPTION
Solving problem that currently the Minuit2.jl is a heavy framework rather a fitting engine.

I considered two options:
1. Move Minuit2 fitting functionality to another light weight package, Minuit2Core
2. Move additional packages to weak dependancies

and picked the 2. to better much the name of the package

Fix #50 
Fix #49

## Summary

- Move Distributions, FHist, Polynomials, RecipesBase, SpecialFunctions, StatsBase, and Plots out of hard package dependencies and into weakdeps/extensions.
- Load distribution helpers, RooFit, and RooFit plotting functionality through dedicated extension modules while keeping the public `Minuit2.RooFit` namespace.
- Replace the core `Distributions` dependency used for chi-square confidence conversions with small internal helpers.
- Update tests, docs, and examples environments so optional dependencies are loaded explicitly where extension-backed APIs are used.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test(julia_args=["--threads=2"])'`
- `julia --project=docs docs/literate.jl roofit_basics`
- `julia --project=docs docs/literate.jl combined`
- `julia --project=docs docs/literate.jl roofit`